### PR TITLE
DeclarativeBase should have been DeclarativeMeta

### DIFF
--- a/db/models.py
+++ b/db/models.py
@@ -5,7 +5,7 @@ Created on Aug 6, 2024
 """
 
 from sqlalchemy import MetaData, Table, Column, Integer, String, Text, DateTime
-from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy.orm import DeclarativeMeta
 from sqlalchemy.sql import func
 
 
@@ -66,7 +66,7 @@ applications_table = Table(
 )
 
 
-class Base(DeclarativeBase):
+class Base(DeclarativeMeta):
     pass
 
 


### PR DESCRIPTION
DeclarativeBase is not a real class of sqlalchemy.orm - DeclarativeMeta is.